### PR TITLE
Faderport 14 bit fader -> two byte key

### DIFF
--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -492,6 +492,7 @@ void Midi_ControlSurface::ProcessMidiWidget(int &lineNumber, ifstream &surfaceTe
 
         string oneByteKey = "";
         string twoByteKey = "";
+        string twoByteKeyMsg2 = "";
         string threeByteKey = "";
         string threeByteKeyMsg2 = "";
         
@@ -511,6 +512,7 @@ void Midi_ControlSurface::ProcessMidiWidget(int &lineNumber, ifstream &surfaceTe
             message2.midi_message[1] = strToHex(tokenLines[i][5]);
             message2.midi_message[2] = strToHex(tokenLines[i][6]);
             
+            twoByteKeyMsg2 = to_string(message2.midi_message[0] * 0x10000 + message2.midi_message[1] * 0x100);
             threeByteKeyMsg2 = to_string(message2.midi_message[0] * 0x10000 + message2.midi_message[1] * 0x100 + message2.midi_message[2]);
         }
         
@@ -527,7 +529,11 @@ void Midi_ControlSurface::ProcessMidiWidget(int &lineNumber, ifstream &surfaceTe
         else if (widgetType == "Fader14Bit" && size == 4)
             CSIMessageGeneratorsByMessage_.insert(make_pair(oneByteKey, make_unique<Fader14Bit_Midi_CSIMessageGenerator>(csi_, widget)));
         else if (widgetType == "FaderportClassicFader14Bit" && size == 7)
-            CSIMessageGeneratorsByMessage_.insert(make_pair(oneByteKey, make_unique<FaderportClassicFader14Bit_Midi_CSIMessageGenerator>(csi_, widget, message1, message2)));
+        {
+            shared_ptr<MIDI_event_ex_t> message1Ptr = make_shared<MIDI_event_ex_t>(message1);
+            CSIMessageGeneratorsByMessage_.insert(make_pair(twoByteKey, make_unique<FaderportClassicFader14Bit_Midi_CSIMessageGenerator>(csi_, widget, message1Ptr, message2)));
+            CSIMessageGeneratorsByMessage_.insert(make_pair(twoByteKeyMsg2, make_unique<FaderportClassicFader14Bit_Midi_CSIMessageGenerator>(csi_, widget, message1Ptr, message2)));
+        }
         else if (widgetType == "Fader7Bit" && size== 4)
             CSIMessageGeneratorsByMessage_.insert(make_pair(twoByteKey, make_unique<Fader7Bit_Midi_CSIMessageGenerator>(csi_, widget)));
         else if (widgetType == "Encoder" && widgetClass == "RotaryWidgetClass")

--- a/reaper_csurf_integrator/control_surface_midi_widgets.h
+++ b/reaper_csurf_integrator/control_surface_midi_widgets.h
@@ -96,19 +96,19 @@ class FaderportClassicFader14Bit_Midi_CSIMessageGenerator : public Midi_CSIMessa
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 {
 protected:
-    MIDI_event_ex_t message1_;
+    shared_ptr<MIDI_event_ex_t> message1_;
     MIDI_event_ex_t message2_;
 
 public:
     virtual ~FaderportClassicFader14Bit_Midi_CSIMessageGenerator() {}
-    FaderportClassicFader14Bit_Midi_CSIMessageGenerator(CSurfIntegrator *const csi, Widget *widget, MIDI_event_ex_t message1, MIDI_event_ex_t message2) : Midi_CSIMessageGenerator(csi, widget), message1_(message1), message2_(message2) {}
+    FaderportClassicFader14Bit_Midi_CSIMessageGenerator(CSurfIntegrator *const csi, Widget *widget, shared_ptr<MIDI_event_ex_t> message1, MIDI_event_ex_t message2) : Midi_CSIMessageGenerator(csi, widget), message1_(message1), message2_(message2) {}
     
     virtual void ProcessMidiMessage(const MIDI_event_ex_t *midiMessage) override
     {
-        if (message1_.midi_message[1] == midiMessage->midi_message[1])
-            message1_.midi_message[2] = midiMessage->midi_message[2];
+        if (message1_->midi_message[1] == midiMessage->midi_message[1])
+            message1_->midi_message[2] = midiMessage->midi_message[2];
         else if (message2_.midi_message[1] == midiMessage->midi_message[1])
-            widget_->GetZoneManager()->DoAction(widget_, int14ToNormalized(message1_.midi_message[2], midiMessage->midi_message[2]));
+            widget_->GetZoneManager()->DoAction(widget_, int14ToNormalized(message1_->midi_message[2], midiMessage->midi_message[2]));
     }
 };
 


### PR DESCRIPTION
I have a Novation LaunchKey mk4. It can transmit 14-bit fader and encoder data, and uses an MSB/LSB encoding via CC parameters separated by 20h. This is captured perfectly by the FaderportClassicFader14Bit message generator type.

However, the FaderportClassicFader14Bit message generator uses a one-byte key, which means that it hogs all possible CC parameters on a given channel. The Novation sends slider data for multiple faders and pots via MSB/LSB CC pairs on the same channel, and as such does not work with the FaderportClassicFader14Bit message generator as it stands now.

As far as I can tell, there is no reason for this message generator to use only a one-byte key. This pull request updates it to use a two-byte key, which means that it works not only with the Faderport Classic, but also the Novation range. (Actually, there are now two two-byte keys: one for the MSB and one for the LSB.)