### PR TITLE
Bugfix in RebuildTracks()

### DIFF
--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -3339,7 +3339,9 @@ void TrackNavigationManager::RebuildTracks()
     int oldTracksSize = (int) tracks_.size();
     bool hasChanged = false;
   
-    if (oldTracksSize == GetNumTracks())
+    if (oldTracksSize != GetNumTracks())
+        hasChanged = true;
+    else
     {
         for (int i = 1; i <= GetNumTracks(); ++i)
             if (MediaTrack* track = CSurf_TrackFromID(i, followMCP_))


### PR DESCRIPTION
This addresses what seems to be a bug in RebuildTracks(): it fails to rebuild the tracks if the number of tracks in Reaper has changed. Rather, it only rebuilds if the number of tracks is the same, but their disposition is different. This doesn't seem like the desired behaviour. This fixes it.